### PR TITLE
Config based on open image from docker hub

### DIFF
--- a/radixconfig.yaml
+++ b/radixconfig.yaml
@@ -1,0 +1,66 @@
+apiVersion: radix.equinor.com/v1
+kind: RadixApplication
+metadata:
+  name: zephyre-aj-fork
+spec:
+  environments:
+    - name: dev
+      build:
+        from: master
+  components:
+    - name: authentication
+      image: lightenup/auth-zephyre-api:{imageTagName}
+      ports:
+        - name: http
+          port: 9000
+      public: true
+      environmentConfig:
+        - environment: dev
+          imageTagName: latest
+          variables:
+            RESOURCE: "7796f701-cf08-4729-b85f-a868ed5f483f"
+            TENANT: "3aa4a235-b6e2-48d5-9195-7fcf05b459b0"
+            AUTHORITY_HOST_URL: "https://login.microsoftonline.com"
+            CLIENT_ID: "7796f701-cf08-4729-b85f-a868ed5f483f"
+            REDIRECT_URL: "https://authentication-zephyre-dev.playground.radix.equinor.com/token"
+            PORT: 9000
+      secrets:
+        - CLIENT_SECRET
+        - APPLICATION_SECRET_KEY
+    - name: resource
+      ingressConfiguration:
+        - websocketfriendly
+      image: lightenup/resource-zephyre-api:{imageTagName}
+      ports:
+        - name: http
+          port: 9010
+      public: true
+      environmentConfig:
+        - environment: dev
+          imageTagName: latest
+          replicas: 2
+          resources:
+            requests:
+              memory: "1024Mi"
+              cpu: "500m"
+            limits:
+              memory: "4096Mi"
+              cpu: "900m"
+          variables:
+            TENANT: "3aa4a235-b6e2-48d5-9195-7fcf05b459b0"
+            AUTHORITY_HOST_URL: "https://login.microsoftonline.com"
+            CLIENT_ID: "7796f701-cf08-4729-b85f-a868ed5f483f"
+            TOKEN_ISSUER_HOST: "https://sts.windows.net/"
+            RESOURCE: "7796f701-cf08-4729-b85f-a868ed5f483f"
+            SERVER_PORT: 9010
+            SERVER_HOST: 0.0.0.0
+            BAZE_URL: jdbc:hive2://northeurope.azuredatabricks.net:443/default;transportMode=http;ssl=true;httpPath=sql/protocolv1/o/4244953073543257/0120-144726-niche729;AuthMech=3;http.header.Connection=close
+            VERTX_BLOCKED_THREAD_CHECK_MS: 3600000
+            VERTXWEB_ENVIRONMENT: exposed-to-internet
+      secrets:
+        - CLIENT_SECRET
+        - APPLICATION_SECRET_KEY
+        - BAZE_USERNAME
+        - BAZE_PASSWORD
+        - SECURITY_GROUP
+        - ROW_STREAM_FETCH_SIZE


### PR DESCRIPTION
This config uses an image from docker hub, but does not
defining a 'privateImageHubs' as mentioned in the Radix doc.
Assumingly this is because images used are open.