### PR TITLE
Use 'johnnycache' images instead of 'equinor'

### DIFF
--- a/radixconfig.yaml
+++ b/radixconfig.yaml
@@ -9,7 +9,7 @@ spec:
         from: master
   components:
     - name: authentication
-      image: equinor/auth-zephyre-api:{imageTagName}
+      image: johnnycache/auth-zephyre-api:{imageTagName}
       ports:
         - name: http
           port: 9000
@@ -30,7 +30,7 @@ spec:
     - name: resource
       ingressConfiguration:
         - websocketfriendly
-      image: equinor/resource-zephyre-api:{imageTagName}
+      image: johnnycache/resource-zephyre-api:{imageTagName}
       ports:
         - name: http
           port: 9010


### PR DESCRIPTION
Because we are unable use to push to the 'equinor' repo
on docker hub we'll have to use 'johnnycache' instead.