### PR TITLE
Define number of replicas for auth server

### DIFF
--- a/radixconfig.yaml
+++ b/radixconfig.yaml
@@ -17,6 +17,7 @@ spec:
       environmentConfig:
         - environment: dev
           imageTagName: latest
+          replicas: 1
           variables:
             RESOURCE: "7796f701-cf08-4729-b85f-a868ed5f483f"
             TENANT: "3aa4a235-b6e2-48d5-9195-7fcf05b459b0"


### PR DESCRIPTION
Due to a bug in Radix when need to define a number of replicas
for any component defined.